### PR TITLE
fix(metrics): remove `label_names` from trainining args

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -98,7 +98,6 @@ def main(
     # trainer
     training_args = TrainingArguments(
         output_dir=output_dir,
-        label_names=label_list,
         per_device_train_batch_size=batch_size,
         per_device_eval_batch_size=batch_size,
         gradient_accumulation_steps=1,


### PR DESCRIPTION
Metrics are not computed because in `Trainer.prediction_step`, the parameter `has_labels` is False due to label_names being a lst of sting where as actual labels are a tensor an not a dict.

Fixes #4 